### PR TITLE
Add key input configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Allows switching to use events from the browser to preview settings without havi
 
 ### Key input
 
+### Show key input - `key_input_show`
+
+- `true` - default
+- `false`
+
+Show/hide the key input indicator.
+
 #### Font color - `key_input_color`
 
 A hex color for the font of the key input indicator.

--- a/src/components/ConfigurationEditor.tsx
+++ b/src/components/ConfigurationEditor.tsx
@@ -20,6 +20,10 @@ const ConfigurationEditorImpl: React.FC<Props> = (props) => {
     ),
 
     "Key Input": folder({
+      key_input_show: {
+        label: "Show Key Input",
+        value: configuration.key_input_show,
+      },
       key_input_color: {
         label: "Font Color",
         value: configuration.key_input_color,

--- a/src/components/KeyboardInput.tsx
+++ b/src/components/KeyboardInput.tsx
@@ -67,7 +67,7 @@ export const KeyboardInput: React.FC = () => {
 
   const keyCodes = sortKeys(pressedKeys);
 
-  return (
+  return configuration.key_input_show ? (
     <motion.div className="fixed bottom-16 left-0 right-0 flex justify-center items-end">
       <AnimatePresence>
         {pressedKeys.size > 0 && (
@@ -98,5 +98,5 @@ export const KeyboardInput: React.FC = () => {
         )}
       </AnimatePresence>
     </motion.div>
-  );
+  ) : null;
 };

--- a/src/hooks/useConfiguration.tsx
+++ b/src/hooks/useConfiguration.tsx
@@ -10,6 +10,7 @@ const configSchema = z.object({
   configuration_ui: z.boolean().default(true),
   event_source: z.enum(["web_socket", "browser"]).default("browser"),
 
+  key_input_show: z.boolean().default(true),
   key_input_color: z.string().default("#FFFFFF"),
   key_input_bg: z.string().default("#334155"),
   key_input_down_bg: z.string().default("#1E293B"),


### PR DESCRIPTION
Add some options for configuring the look of the key input indicator and add documentation. Fix a clunky animation issue by manipulating the animation object instead of using controls.start.